### PR TITLE
Fix: Auto detect SSL on Swagger UI server generation

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -35,8 +35,6 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3")
-
-
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -6,3 +6,4 @@ spring.datasource.password=${MYSQL_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.properties.hibernate.show_sql=true
 springdoc.swagger-ui.path=/
+server.forward-headers-strategy=framework


### PR DESCRIPTION
## Descripción

Agrega una línea al archivo de configuración de Spring:

`server.forward-headers-strategy=framework`

Esto hace que Swagger UI auto-detecte el esquema HTTPS a través de los headers de la petición HTTP al generar el servidor.