### PR TITLE
refactor: decouple FurnitureMapper from category repository

### DIFF
--- a/backend/src/main/java/tech/nocountry/c23e64/mapper/CategoryMapper.java
+++ b/backend/src/main/java/tech/nocountry/c23e64/mapper/CategoryMapper.java
@@ -1,16 +1,16 @@
 package tech.nocountry.c23e64.mapper;
 
 import org.mapstruct.Mapper;
-import org.springframework.stereotype.Component;
+import org.mapstruct.Mapping;
 import tech.nocountry.c23e64.dto.CategoryCreateDto;
 import tech.nocountry.c23e64.dto.CategoryDto;
 import tech.nocountry.c23e64.model.CategoryEntity;
-import tech.nocountry.c23e64.repository.CategoryRepository;
 
 @Mapper(componentModel = "spring")
 public interface CategoryMapper {
 
     CategoryDto toDto(CategoryEntity categoryEntity);
 
+    @Mapping(target = "id", ignore = true)
     CategoryEntity toEntity(CategoryCreateDto createDto);
 }

--- a/backend/src/main/java/tech/nocountry/c23e64/mapper/FurnitureMapper.java
+++ b/backend/src/main/java/tech/nocountry/c23e64/mapper/FurnitureMapper.java
@@ -1,27 +1,19 @@
 package tech.nocountry.c23e64.mapper;
 
-import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 import tech.nocountry.c23e64.dto.FurnitureCreateDto;
 import tech.nocountry.c23e64.dto.FurnitureDto;
-import tech.nocountry.c23e64.model.CategoryEntity;
 import tech.nocountry.c23e64.model.FurnitureEntity;
-import tech.nocountry.c23e64.repository.CategoryRepository;
 
 @Mapper(componentModel = "spring")
 public abstract class FurnitureMapper {
 
-    @Mapping(source = "categoryId", target = "category", qualifiedByName = "mapCategory")
     @Mapping(target = "id", ignore = true)
-    public abstract FurnitureEntity toEntity(FurnitureCreateDto createDto, @Context CategoryRepository categoryRepository);
+    @Mapping(target = "category", ignore = true)
+    public abstract FurnitureEntity toEntity(FurnitureCreateDto createDto);
 
     @Mapping(source = "category.name", target = "category")
     public abstract FurnitureDto toDto(FurnitureEntity furnitureEntity);
 
-    @Named("mapCategory")
-    public CategoryEntity mapCategory(Long id, @Context CategoryRepository categoryRepository) {
-        return categoryRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("La categoría con ID " + id + " no existe"));
-    }
 }

--- a/backend/src/main/java/tech/nocountry/c23e64/service/FurnitureServiceImpl.java
+++ b/backend/src/main/java/tech/nocountry/c23e64/service/FurnitureServiceImpl.java
@@ -32,8 +32,13 @@ public class FurnitureServiceImpl implements FurnitureService {
         if (furnitureRepository.existsByName(createDto.getName())) {
             throw new DuplicateResourceException("El mueble con nombre '" + createDto.getName() + "' ya existe.");
         }
+        CategoryEntity categoryEntity = categoryRepository
+                .findById(createDto.getCategoryId())
+                .orElseThrow(() -> new IllegalArgumentException("La categoría con ID " + createDto.getCategoryId() + " no existe"));
 
-        FurnitureEntity furnitureEntity = furnitureMapper.toEntity(createDto, categoryRepository);
+        FurnitureEntity furnitureEntity = furnitureMapper.toEntity(createDto);
+        furnitureEntity.setCategory(categoryEntity);
+
         furnitureRepository.save(furnitureEntity);
         return furnitureMapper.toDto(furnitureEntity);
     }
@@ -50,7 +55,9 @@ public class FurnitureServiceImpl implements FurnitureService {
             furnitureEntity.setName(updateDto.getName());
         }
         if (updateDto.getCategoryId() != null) {
-            CategoryEntity categoryEntity = categoryRepository.findById(updateDto.getCategoryId()).orElseThrow(() -> new IllegalArgumentException("La categoría con ID " + updateDto.getCategoryId() + " no existe"));
+            CategoryEntity categoryEntity = categoryRepository
+                    .findById(updateDto.getCategoryId())
+                    .orElseThrow(() -> new IllegalArgumentException("La categoría con ID " + updateDto.getCategoryId() + " no existe"));
             furnitureEntity.setCategory(categoryEntity);
         }
         if (updateDto.getStock() != null) {
@@ -72,7 +79,9 @@ public class FurnitureServiceImpl implements FurnitureService {
 
     @Override
     public FurnitureDto getFurnitureById(Long id) {
-        FurnitureEntity furnitureEntity = furnitureRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("El mueble con ID " + id + " no existe"));
+        FurnitureEntity furnitureEntity = furnitureRepository
+                .findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("El mueble con ID " + id + " no existe"));
 
         return furnitureMapper.toDto(furnitureEntity);
     }


### PR DESCRIPTION
## Descripción

Esta PR hace que el mapper de Furniture ya no necesite utilizar el repositorio de categorías. Anteriormente, el mapper mostraba baja cohesión porque era el encargado de arrojar una excepción si la categoría no existía (esa responsabilidad es ahora del servicio de mobiliario, como corresponde). Además, el mapper necesitaba relacionarse con el repositorio, lo cual causaba acoplamiento innecesario.