### PR TITLE
fix: add rental id to email subject for clarity

### DIFF
--- a/backend/src/main/java/tech/nocountry/c23e64/service/RentalEmailServiceImpl.java
+++ b/backend/src/main/java/tech/nocountry/c23e64/service/RentalEmailServiceImpl.java
@@ -30,7 +30,7 @@ public class RentalEmailServiceImpl implements RentalEmailService {
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
             helper.setFrom(from);
             helper.setTo(to);
-            helper.setSubject("Confirmación de Reserva");
+            helper.setSubject("Confirmación de Reserva #" + rental.getId());
             helper.addInline("embeddedImage", qrCode, "image/" + "png");
 
             String formattedDate = rental.getRentalDate().format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));


### PR DESCRIPTION
## Descripción

Esta PR agrega el id de reserva al _subject_ del email que se envía al cliente. Esto deja más claro que el email es sobre una reserva particular y evita que el email aparezca como una respuesta a otra reserva anterior en ciertos proveedores de email.